### PR TITLE
Remove AnalyzeTemporaryDtors option

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -37,7 +37,6 @@ Checks:
 '
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 FormatStyle:     none
 CheckOptions:
   llvm-else-after-return.WarnOnConditionVariables: 'false'


### PR DESCRIPTION
It was deprecated in clang-tidy 16, and fully removed in clang-tidy 18.