### PR TITLE
TTDevice: PushMarkerLockfree, and the Dequeue cases it needs

### DIFF
--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -2837,6 +2837,23 @@ Profiler::DequeueStatus Profiler::Dequeue( moodycamel::ConsumerToken& token )
                         SendSingleString( (const char*)ptr, size );
                         tracy_free_fast( (void*)ptr );
                         break;
+                    case QueueType::GpuMarkerMeta:
+                        ptr = MemRead<uint64_t>( &item->gpuMarkerMetaFat.ptr );
+                        size = MemRead<uint16_t>( &item->gpuMarkerMetaFat.size );
+                        SendSingleString( (const char*)ptr, size );
+                        tracy_free_fast( (void*)ptr );
+                        break;
+                    case QueueType::GpuMarker:
+                    {
+                        int64_t t = MemRead<int64_t>( &item->gpuMarker.gpuTime );
+                        int64_t dt = t - refGpu;
+                        refGpu = t;
+                        MemWrite( &item->gpuMarker.gpuTime, dt );
+                        ptr = MemRead<uint64_t>( &item->gpuMarker.srcloc );
+                        SendSourceLocationPayload( ptr );
+                        tracy_free_fast( (void*)ptr );
+                        break;
+                    }
                     case QueueType::PlotDataInt:
                     case QueueType::PlotDataFloat:
                     case QueueType::PlotDataDouble:

--- a/public/tracy/TracyTTDevice.hpp
+++ b/public/tracy/TracyTTDevice.hpp
@@ -13,6 +13,7 @@
 #define TracyTTPushStartZone(c, e)
 #define TracyTTPushEndZone(c, e)
 #define TracyTTPushMarker(c, e)
+#define TracyTTPushMarkerLockfree(c, e)
 #define TracyTTPushZone(c, s, t, b, e)
 #define TracyTTPushZoneSerial(c, s, t, b, e)
 
@@ -390,6 +391,44 @@ namespace tracy {
             Profiler::QueueSerialFinish();
         }
 
+        // Lock-free twin of PushMarker. Use only when this context was also created lock-free on this
+        // thread: the client drains the lock-free queues before the serial one, and they are per-thread,
+        // so either mismatch lets a marker reach the server ahead of the context it references.
+        void PushMarkerLockfree(const TTDeviceMarker& marker) {
+            const tracy::Color::ColorType color = this->getMarkerColor(marker);
+
+            const auto srcloc = Profiler::AllocSourceLocation(
+                marker.line,
+                marker.file.c_str(),
+                marker.file.length(),
+                "",
+                0,
+                marker.marker_name.c_str(),
+                marker.marker_name.length(),
+                color);
+
+            const std::string meta = this->getMarkerMetaString(marker);
+            if (!meta.empty()) {
+                const uint16_t metaLen = (uint16_t)std::min<size_t>(meta.length(), std::numeric_limits<uint16_t>::max());
+                auto ptr = (char*)tracy_malloc(metaLen);
+                memcpy(ptr, meta.c_str(), metaLen);
+
+                TracyLfqPrepare(QueueType::GpuMarkerMeta);
+                MemWrite(&item->gpuMarkerMetaFat.context, this->GetId());
+                MemWrite(&item->gpuMarkerMetaFat.ptr, (uint64_t)ptr);
+                MemWrite(&item->gpuMarkerMetaFat.size, metaLen);
+                TracyLfqCommit;
+            }
+
+            TracyLfqPrepare(QueueType::GpuMarker);
+            MemWrite(&item->gpuMarker.gpuTime, (int64_t)round((double)marker.timestamp / m_frequency));
+            MemWrite(&item->gpuMarker.srcloc, srcloc);
+            MemWrite(&item->gpuMarker.thread, (uint32_t)marker.get_thread_id());
+            MemWrite(&item->gpuMarker.context, this->GetId());
+            MemWrite(&item->gpuMarker.markerType, (uint8_t)marker.marker_type);
+            TracyLfqCommit;
+        }
+
         // Per (context, thread), calls must arrive in zone completion order (i.e., sorted by `end`); the server rebuilds nesting from that ordering.
         tracy_force_inline void PushZone(
             const SourceLocationData* srcloc, uint32_t thread, uint64_t start, uint64_t end) {
@@ -492,6 +531,7 @@ using TracyTTCtx = tracy::TTCtx*;
 #define TracyTTPushStartMarker(ctx, marker) ctx->PushStartMarker(marker)
 #define TracyTTPushEndMarker(ctx, marker) ctx->PushEndMarker(marker)
 #define TracyTTPushMarker(ctx, marker) ctx->PushMarker(marker)
+#define TracyTTPushMarkerLockfree(ctx, marker) ctx->PushMarkerLockfree(marker)
 #define TracyTTPushZone(ctx, srcloc, thread, start, end) ctx->PushZone(srcloc, thread, start, end)
 #define TracyTTPushZoneSerial(ctx, srcloc, thread, start, end) ctx->PushZoneSerial(srcloc, thread, start, end)
 


### PR DESCRIPTION
The lock-free twin of PushMarker, for a producer whose context is also created lock-free on the same thread.

Markers could not simply change queues the way zones did. GpuMarker and GpuMarkerMeta were handled only in DequeueSerial, so a marker on the lock-free queue would have had its srcloc payload never sent, its timestamp never delta-encoded against refGpu, and both of its allocations leaked -- one srcloc and one meta string per marker, silently. Profiler::Dequeue now carries the same two cases; they must stay in sync with the serial pair.

GpuZone needs no case in either dequeue, because it ships absolute timestamps and a static srcloc that is never freed. That is what made the zone path a one-line move to the lock-free queue and this one not.