### PR TITLE
GUI: integer MinVisNs in the GPU zone level walk

### DIFF
--- a/profiler/src/profiler/TracyView_GpuTimeline.cpp
+++ b/profiler/src/profiler/TracyView_GpuTimeline.cpp
@@ -292,7 +292,7 @@ int View::DrawGpuZoneLevel( const V& vec, bool hover, double pxns, int64_t nspx,
         if( zsz < MinVisSize )
         {
             const auto color = GetZoneColor( ev );
-            const auto MinVisNs = MinVisSize * nspx;
+            const auto MinVisNs = int64_t( round( MinVisSize * nspx ) );
             int num = 0;
             const auto px0 = ( start - m_vd.zvStart ) * pxns;
             auto px1ns = end - m_vd.zvStart;
@@ -469,7 +469,7 @@ int View::SkipGpuZoneLevel( const V& vec, bool hover, double pxns, int64_t nspx,
         const auto zsz = std::max( ( end - start ) * pxns, pxns * 0.5 );
         if( zsz < MinVisSize )
         {
-            const auto MinVisNs = MinVisSize * nspx;
+            const auto MinVisNs = int64_t( round( MinVisSize * nspx ) );
             auto px1ns = end - m_vd.zvStart;
             auto nextTime = end + MinVisNs;
             for(;;)


### PR DESCRIPTION
MinVisSize is a float, so MinVisNs and nextTime in DrawGpuZoneLevel and SkipGpuZoneLevel were single precision. Past ~2^39 ns into a trace (~9 min) a float's quantum is 65,536 ns, so the too-small-to-draw grouping's lower_bound(nextTime) could jump up to 65 us and swallow every zone ending in that window: zones visible when zoomed in vanished when zoomed out, and whole lane rows ended early. Every other level walk already rounds to int64_t; do the same here.